### PR TITLE
Setup end-of-line normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.ai binary
+*.pdf binary
+
+*.jpg binary
+*.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,16 @@
 
 *.jpg binary
 *.png binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary


### PR DESCRIPTION
According to https://help.github.com/articles/dealing-with-line-endings/  and https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html#_checking_out_and_checking_in  setting up `.gitattributes` with `text=auto` should force Git to convert all text files to LF line endings internally and thus enable Windows users to work on this project using native line endings without introducing CRLF format to the repository.

Please correct me if I misunderstood something :)